### PR TITLE
Added cast to prevent compile error

### DIFF
--- a/src/world.c
+++ b/src/world.c
@@ -86,7 +86,7 @@ static int loop(
             terrain_neighbors2(&terrain, x, z, neighbors);
             chunk->mesh = !voxel_vbo(
                 chunk,
-                neighbors,
+                (const chunk_t**) neighbors,
                 device,
                 worker->tbos,
                 worker->sizes);


### PR DESCRIPTION
Compilation was failing otherwise due to the different type.

```
/archive/shared/projects/blocks/src/world.c: In function ‘loop’:
/archive/shared/projects/blocks/src/world.c:86:48: error: passing argument 4 of ‘terrain_neighbors2’ from incompatible pointer type [-Wincompatible-pointer-types]
   86 |             terrain_neighbors2(&terrain, x, z, neighbors);
      |                                                ^~~~~~~~~
      |                                                |
      |                                                const chunk_t **
```